### PR TITLE
Add API key modal and refactor key handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,9 +5,19 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Adaptive VSP Builder</title>
   <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="style.css">
 </head>
 <body class="bg-gray-100 p-4">
-  <div class="max-w-4xl mx-auto space-y-6">
+  <!-- API Key Modal -->
+  <div id="api-modal" class="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50">
+    <div class="bg-white p-6 rounded shadow-md space-y-4 w-11/12 sm:w-96">
+      <p class="text-center font-semibold">Enter your OpenAI API Key to begin</p>
+      <input id="api-key-input" type="password" class="w-full border rounded p-2" />
+      <button id="api-continue" class="w-full bg-blue-600 text-white py-2 rounded">Continue</button>
+    </div>
+  </div>
+
+  <div id="app-container" class="max-w-4xl mx-auto space-y-6" style="display:none;">
     <h1 class="text-2xl font-bold">Adaptive VSP Builder</h1>
 
     <!-- Case Builder -->
@@ -43,11 +53,9 @@
           <textarea id="patient-free" class="w-full border rounded p-2" placeholder="Use natural language to describe the patient case"></textarea>
         </div>
       </div>
-      <div class="mt-4 flex items-center space-x-2">
-        <input id="openai-key" type="password" placeholder="OpenAI API Key" class="border rounded p-2 flex-grow" />
-        <button id="start-btn" class="bg-blue-600 text-white px-4 py-2 rounded">Start Simulation</button>
+      <div class="mt-4 flex items-center">
+        <button id="start-btn" class="bg-blue-600 text-white px-4 py-2 rounded w-full">Start Simulation</button>
       </div>
-      <p class="text-xs text-red-600 mt-2">Do not publish your API key publicly.</p>
     </section>
 
     <!-- Chat Window -->

--- a/script.js
+++ b/script.js
@@ -139,7 +139,6 @@ async function handleSend() {
 
 function startSimulation() {
   console.log('startSimulation called');
-  apiKey = document.getElementById('openai-key').value.trim();
   if (!apiKey) {
     alert('Please enter your OpenAI API key.');
     return;
@@ -163,5 +162,21 @@ document.addEventListener('DOMContentLoaded', () => {
   document.getElementById('send-btn').addEventListener('click', handleSend);
   document.getElementById('chat-input').addEventListener('keypress', e => {
     if (e.key === 'Enter') handleSend();
+  });
+
+  const modal = document.getElementById('api-modal');
+  const continueBtn = document.getElementById('api-continue');
+  const keyInput = document.getElementById('api-key-input');
+
+  continueBtn.addEventListener('click', () => {
+    const key = keyInput.value.trim();
+    if (!key) {
+      alert('Please enter your OpenAI API key.');
+      return;
+    }
+    apiKey = key;
+    window.apiKey = key;
+    modal.style.display = 'none';
+    document.getElementById('app-container').style.display = 'block';
   });
 });

--- a/style.css
+++ b/style.css
@@ -1,0 +1,9 @@
+#api-modal {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 50;
+}


### PR DESCRIPTION
## Summary
- add new API key modal on page load
- remove inline API key field
- store API key in global variable once user continues
- block the interface until key entered
- add minimal CSS for modal

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_684c06446ef88331ad4fe0e477d18042