### PR TITLE
Improve usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,17 @@
 # VSPatients
 
 This project provides a simple web interface for building virtual standardized patient (VSP) scenarios. Fill out the form in `index.html` to define patient details and then chat with the simulated patient powered by OpenAI's API via `script.js`.
+
+## Running Locally
+
+Instead of opening `index.html` directly, serve the project directory with a minimal HTTP server. If you have Python installed you can run:
+
+```bash
+python3 -m http.server 8000
+```
+
+Then visit [http://localhost:8000/](http://localhost:8000/) in your browser.
+
+Browser requests to the OpenAI API can fail due to CORS restrictions. If you encounter network errors, consider running a backend proxy that forwards requests to the API.
+
+If clicking **Continue** after entering your API key does nothing, open the browser console and check for errors.


### PR DESCRIPTION
## Summary
- expand README with instructions on serving the site via a local HTTP server
- mention potential CORS issues requiring a backend proxy
- add note about checking the browser console if the Continue button fails

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_684c08e3bf44833183cddd8bd4264ab9