### PR TITLE
Add console logs to API continue handler

### DIFF
--- a/script.js
+++ b/script.js
@@ -184,14 +184,18 @@ document.addEventListener('DOMContentLoaded', () => {
   const keyInput = document.getElementById('api-key-input');
 
   continueBtn.addEventListener('click', () => {
+    console.log('api-continue handler start');
     const key = keyInput.value.trim();
+    console.log('api key entered:', key);
     if (!key) {
       alert('Please enter your OpenAI API key.');
       return;
     }
     apiKey = key;
     window.apiKey = key;
+    console.log('apiKey set on window');
     modal.style.display = 'none';
+    console.log('api modal hidden');
     document.getElementById('app-container').style.display = 'block';
   });
 });


### PR DESCRIPTION
## Summary
- log when api-continue handler starts
- log the entered API key
- log when the key is stored and modal hidden

## Testing
- `python3 -m http.server 8000` *(fails: not able to open browser to view console)*

------
https://chatgpt.com/codex/tasks/task_b_684c0aa3a9a88331990dc5a5ba3691be