### PR TITLE
Improve consultation feedback and case diversity

### DIFF
--- a/style.css
+++ b/style.css
@@ -17,7 +17,7 @@
 }
 #score-bar {
   height: 100%;
-  width: 0%;
-  background: red;
+  width: 50%;
+  background: linear-gradient(90deg, red, yellow, green);
   transition: width 0.4s ease, background 0.4s ease;
 }


### PR DESCRIPTION
## Summary
- add baseline gradient for the score bar
- start consultation score at 50 and log updates
- expand system prompt so VSP waits for questions
- diversify random case generation prompt and log API calls
- add extensive debugging logs

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_684c164bceb48331b230bc4ac6fe30f2