### PR TITLE
Add occupation field to case builder

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,6 +32,10 @@
           <label class="block text-sm font-medium">Age</label>
           <input id="patient-age" type="text" class="w-full border rounded p-2" value="72" />
         </div>
+        <div>
+          <label class="block text-sm font-medium">Occupation</label>
+          <input id="patient-occupation" type="text" class="w-full border rounded p-2" value="Retired schoolteacher" />
+        </div>
         <div class="md:col-span-2">
           <label class="block text-sm font-medium">Background</label>
           <textarea id="patient-background" class="w-full border rounded p-2">Retired schoolteacher living in a rural town, has Type 2 diabetes</textarea>

--- a/script.js
+++ b/script.js
@@ -11,6 +11,8 @@ function buildPrompt() {
   console.log('name:', name);
   const age = document.getElementById('patient-age').value.trim();
   console.log('age:', age);
+  const occupation = document.getElementById('patient-occupation').value.trim();
+  console.log('occupation:', occupation);
   const background = document.getElementById('patient-background').value.trim();
   console.log('background:', background);
   const symptoms = document.getElementById('patient-symptoms').value.trim();
@@ -32,8 +34,9 @@ function buildPrompt() {
   const parts = [];
 
   const agePart = age ? `, a ${age}-year-old` : '';
+  const occupationPart = occupation ? ` who is a ${occupation.replace(/\.$/, '')}` : '';
   const backgroundPart = background ? ` ${background.replace(/\.$/, '')}` : '';
-  parts.push(`You are ${patient}${agePart}${backgroundPart}.`);
+  parts.push(`You are ${patient}${agePart}${occupationPart}${backgroundPart}.`);
 
   if (symptoms) {
     parts.push(`You're experiencing ${symptoms}.`);
@@ -251,7 +254,7 @@ async function generateRandomCase() {
   btn.textContent = 'Generating...';
   btn.disabled = true;
 
-  const prompt = `Generate a fictional patient for medical simulation. Return a JSON object with: name, age (between 2–95), background, symptoms, tone, personality, true diagnosis, case description. Ensure personality and age vary each time. Avoid repeating traits like 'stoic'. Use diversity in age, culture, gender, and presentation.`;
+  const prompt = `Generate a fictional patient for medical simulation. Return a JSON object with: name, age (between 2–95), occupation, background, symptoms, tone, personality, true diagnosis, case description. Ensure a broad age distribution across the full range and vary occupations in each case. Avoid repeating traits like 'stoic'. Use diversity in age, culture, gender, and presentation.`;
   console.log('case generation prompt:', prompt);
 
   try {
@@ -279,6 +282,7 @@ async function generateRandomCase() {
 
     document.getElementById('patient-name').value = info.name || '';
     document.getElementById('patient-age').value = info.age || '';
+    document.getElementById('patient-occupation').value = info.occupation || '';
     document.getElementById('patient-background').value = info.background || '';
     document.getElementById('patient-symptoms').value = info.symptoms || '';
     document.getElementById('patient-tone').value = [info.tone, info.personality].filter(Boolean).join(' ');


### PR DESCRIPTION
## Summary
- add Occupation field to form
- include occupation in case generation prompt and parsing
- build prompts using the occupation

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_684c194a27448331ab5e496492688f5e