### PR TITLE
Fix undefined variable in score bar logger

### DIFF
--- a/script.js
+++ b/script.js
@@ -127,7 +127,7 @@ function updateScoreBar() {
   document.getElementById('score-display').innerText = Math.round(consultationScore);
   const notice = document.getElementById('score-notice');
   if (notice) notice.innerText = '';
-  console.log(`score bar width: ${bar.style.width} color: ${color}`);
+  console.log(`score bar width: ${bar.style.width} color: ${bar.style.backgroundColor}`);
 }
 
 async function evaluateConsultation(text) {


### PR DESCRIPTION
## Summary
- fix reference to `color` variable in `updateScoreBar`

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_684c86add0588331be5ffd03078d540f