### PR TITLE
Add Jest tests for core functions

### DIFF
--- a/__tests__/script.test.js
+++ b/__tests__/script.test.js
@@ -1,0 +1,69 @@
+const { JSDOM } = require('jsdom');
+
+const { buildPrompt, similarity, evaluateConsultation } = require('../script');
+
+describe('buildPrompt', () => {
+  beforeEach(() => {
+    const dom = new JSDOM(`<!doctype html><html><body>
+      <input id="patient-name" />
+      <input id="patient-age" />
+      <input id="patient-occupation" />
+      <input id="patient-background" />
+      <input id="patient-symptoms" />
+      <input id="patient-tone" />
+      <input id="patient-free" />
+      <input id="patient-diagnosis" />
+    </body></html>`);
+    global.document = dom.window.document;
+    global.window = dom.window;
+  });
+
+  test('builds prompt from form fields', () => {
+    document.getElementById('patient-name').value = 'John Doe';
+    document.getElementById('patient-age').value = '30';
+    document.getElementById('patient-occupation').value = 'teacher.';
+    document.getElementById('patient-background').value = 'from Texas.';
+    document.getElementById('patient-symptoms').value = 'cough';
+    document.getElementById('patient-tone').value = 'friendly';
+    document.getElementById('patient-free').value = '';
+    document.getElementById('patient-diagnosis').value = 'pneumonia';
+
+    const prompt = buildPrompt();
+    expect(prompt).toContain('You are John Doe, a 30-year-old who is a teacher from Texas');
+    expect(prompt).toContain("You're experiencing cough.");
+    expect(prompt).toContain('You are friendly.');
+    expect(prompt).toContain('Your true diagnosis is pneumonia');
+  });
+
+  test('builds free text prompt', () => {
+    document.getElementById('patient-name').value = 'Jane';
+    document.getElementById('patient-free').value = 'You are at the clinic for a check-up.';
+    const prompt = buildPrompt();
+    expect(prompt).toMatch(/Stay in character as the patient/);
+    expect(prompt).toContain('You are at the clinic for a check-up.');
+  });
+});
+
+describe('similarity', () => {
+  test('computes overlap', () => {
+    expect(similarity('fever cough', 'fever sore throat')).toBeCloseTo(0.5);
+  });
+});
+
+describe('evaluateConsultation', () => {
+  beforeEach(() => {
+    const dom = new JSDOM(`<!doctype html><html><body><div id="score-notice"></div></body></html>`);
+    global.document = dom.window.document;
+    global.window = dom.window;
+    global.window.apiKey = 'test';
+  });
+
+  test('parses numeric response', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ choices: [{ message: { content: '1' } }] })
+    });
+    const val = await evaluateConsultation('hi');
+    expect(val).toBe(1);
+  });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  testEnvironment: 'jsdom'
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "vspatients-",
+  "version": "1.0.0",
+  "description": "This project provides a simple web interface for building virtual standardized patient (VSP) scenarios. Fill out the form in `index.html` to define patient details and then chat with the simulated patient powered by OpenAI's API via `script.js`.",
+  "main": "script.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+  ,
+  "devDependencies": {
+    "jest": "^29.0.0",
+    "jsdom": "^22.0.0"
+  }
+}

--- a/script.js
+++ b/script.js
@@ -338,3 +338,7 @@ document.addEventListener('DOMContentLoaded', () => {
     document.getElementById('app-container').style.display = 'block';
   });
 });
+
+if (typeof module !== "undefined" && module.exports) {
+  module.exports = { buildPrompt, similarity, evaluateConsultation };
+}


### PR DESCRIPTION
## Summary
- configure Jest for unit testing
- export functions from `script.js` for testing
- add Jest config and a basic test suite

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_684c903b46088331b9104e8cdd0240a8