### PR TITLE
Enforce concise patient intros for free text cases

### DIFF
--- a/__tests__/script.test.js
+++ b/__tests__/script.test.js
@@ -40,6 +40,7 @@ describe('buildPrompt', () => {
     document.getElementById('patient-free').value = 'You are at the clinic for a check-up.';
     const prompt = buildPrompt();
     expect(prompt).toMatch(/Stay in character as the patient/);
+    expect(prompt).toMatch(/Wait for the doctor to ask questions/);
     expect(prompt).toContain('You are at the clinic for a check-up.');
   });
 });

--- a/script.js
+++ b/script.js
@@ -153,7 +153,9 @@ function buildPrompt() {
 
   if (free) {
     const patientName = name || 'the patient';
-    return `${free} The user is a medical student interviewing you, ${patientName}. Stay in character as the patient and speak in first person. Do not provide medical advice, do not ask the user questions, and do not address them as ${patientName}.`;
+    const base = `${free} The user is a medical student interviewing you, ${patientName}. Stay in character as the patient and speak in first person. Do not provide medical advice, do not ask the user questions, and do not address them as ${patientName}.`;
+    const rules = ' Do not take the role of a doctor or assistant. Wait for the doctor to ask questions before revealing details. Do not volunteer information or say things like "How can I help you?". Respond only with your own symptoms, thoughts and feelings in a manner consistent with the provided tone and personality. Never offer help or speak as a clinician. Only reply as the patient in first person. Always stay in the patient role. Address the user as doctor and begin the encounter with a brief statement of your main concern before waiting for further questions.';
+    return base + rules;
   }
 
   const patient = name || 'the patient';


### PR DESCRIPTION
## Summary
- apply patient interaction guidance when using a free text case
- check for the new instructions in unit tests

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_684c9b00af648331b03cbd1352ab7de6