### PR TITLE
Enhance patient realism in prompt

### DIFF
--- a/__tests__/script.test.js
+++ b/__tests__/script.test.js
@@ -33,6 +33,7 @@ describe('buildPrompt', () => {
     expect(prompt).toContain("You're experiencing cough.");
     expect(prompt).toContain('You are friendly.');
     expect(prompt).toContain('Your true diagnosis is pneumonia');
+    expect(prompt).toMatch(/realistic emotional boundaries/i);
   });
 
   test('builds free text prompt', () => {
@@ -42,6 +43,7 @@ describe('buildPrompt', () => {
     expect(prompt).toMatch(/Stay in character as the patient/);
     expect(prompt).toMatch(/Wait for the doctor to ask questions/);
     expect(prompt).toContain('You are at the clinic for a check-up.');
+    expect(prompt).toMatch(/realistic emotional boundaries/i);
   });
 });
 

--- a/script.js
+++ b/script.js
@@ -156,7 +156,8 @@ function buildPrompt() {
     const base = `${free} The user is a medical student interviewing you, ${patientName}. Stay in character as the patient and speak in first person. Do not provide medical advice, do not ask the user questions, and do not address them as ${patientName}.`;
     const rules = ' Do not take the role of a doctor or assistant. Wait for the doctor to ask questions before revealing details. Do not volunteer information or say things like "How can I help you?". Respond only with your own symptoms, thoughts and feelings in a manner consistent with the provided tone and personality. Never offer help or speak as a clinician. Only reply as the patient in first person. Always stay in the patient role. Address the user as doctor and begin the encounter with a brief statement of your main concern before waiting for further questions.';
     const extra = ' You are simulating a real patient in a clinical consultation. You must only share one or two symptoms at a time unless specifically asked, wait for the clinician to guide the conversation, respond based on your assigned tone and personality, react realistically with emotion or confusion, and avoid robotic agreement to unrealistic requests.';
-    return base + rules + extra;
+    const emotion = ' You have realistic emotional boundaries. Respond in a human, emotionally appropriate way based on your tone and situation. If the doctor behaves strangely or unprofessionally, react accordingly while staying in character.';
+    return base + rules + extra + emotion;
   }
 
   const patient = name || 'the patient';
@@ -181,6 +182,7 @@ function buildPrompt() {
   parts.push('Never offer help or speak as a clinician. Only reply as the patient in first person.');
   parts.push('Always stay in the patient role. Address the user as doctor and begin the encounter with a brief statement of your main concern before waiting for further questions.');
   parts.push('You are simulating a real patient in a clinical consultation. You must only share one or two symptoms at a time unless specifically asked, wait for the clinician to guide the conversation, respond based on your assigned tone and personality, react realistically with emotion or confusion, and avoid robotic agreement to unrealistic requests.');
+  parts.push('You have realistic emotional boundaries. Respond in a human, emotionally appropriate way based on your tone and situation. If the doctor behaves strangely or unprofessionally, react accordingly while staying in character.');
 
   if (trueDiagnosis) {
     parts.push(`Your true diagnosis is ${trueDiagnosis}. Keep this private unless explicitly asked.`);


### PR DESCRIPTION
## Summary
- refine the `buildPrompt` logic to tell the patient to keep realistic emotional boundaries and react naturally to rude or unprofessional behavior
- update unit tests for new prompt text

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_684cb130f2388331a914caa1801344f1