### PR TITLE
Ensure handleSend includes system prompt

### DIFF
--- a/__tests__/script.test.js
+++ b/__tests__/script.test.js
@@ -1,6 +1,7 @@
 const { JSDOM } = require('jsdom');
 
-const { buildPrompt, similarity, evaluateConsultation } = require('../script');
+const scriptModule = require('../script');
+const { buildPrompt, similarity, evaluateConsultation, handleSend, callOpenAI, _setTestState } = scriptModule;
 
 describe('buildPrompt', () => {
   beforeEach(() => {
@@ -70,5 +71,43 @@ describe('evaluateConsultation', () => {
     });
     const val = await evaluateConsultation('hi');
     expect(val).toEqual({ open_questions: 1, empathy: 0, inappropriate_advice: 0 });
+  });
+});
+
+describe('handleSend', () => {
+  beforeEach(() => {
+    const dom = new JSDOM(`<!doctype html><html><body>
+      <input id="chat-input" />
+      <div id="chat-window"></div>
+      <div id="score-display"></div>
+      <div id="score-bar"></div>
+      <div id="diagnosis-display"></div>
+    </body></html>`);
+    global.document = dom.window.document;
+    global.window = dom.window;
+    global.prompt = () => null;
+    _setTestState({
+      systemPrompt: 'Stay in character as the patient.',
+      messageHistory: [],
+      consultationScore: 50,
+      turnCount: 0,
+      trueDiagnosis: 'flu'
+    });
+    global.appendMessage = jest.fn();
+    global.saveCurrentSession = jest.fn();
+    global.evaluateConsultation = jest.fn().mockResolvedValue({ open_questions: 0, empathy: 0, inappropriate_advice: 0 });
+    global.updateScoreBar = jest.fn();
+  });
+
+  test('calls callOpenAI with system prompt prepended', async () => {
+    const input = document.getElementById('chat-input');
+    input.value = 'Hello';
+    const spy = jest.spyOn(scriptModule, 'callOpenAI').mockResolvedValue('hi');
+    await handleSend();
+    expect(spy).toHaveBeenCalled();
+    const arg = spy.mock.calls[0][0];
+    expect(arg[0]).toEqual({ role: 'system', content: 'Stay in character as the patient.' });
+    expect(arg[arg.length - 1]).toEqual({ role: 'user', content: 'Hello' });
+    spy.mockRestore();
   });
 });

--- a/script.js
+++ b/script.js
@@ -338,7 +338,11 @@ async function handleSend() {
   turnCount += 1;
 
   console.log('sending to OpenAI. systemPrompt:', systemPrompt);
-  const reply = await callOpenAI(messageHistory);
+  const messages = [{ role: 'system', content: systemPrompt }, ...messageHistory];
+  if (/you are the doctor|switch roles/i.test(text)) {
+    messages.push({ role: 'system', content: 'Stay in the patient role at all times.' });
+  }
+  const reply = await callOpenAI(messages);
   if (reply) {
     appendMessage('assistant', reply);
     messageHistory.push({ role: 'assistant', content: reply });
@@ -501,5 +505,18 @@ document.addEventListener('DOMContentLoaded', () => {
 });
 
 if (typeof module !== "undefined" && module.exports) {
-  module.exports = { buildPrompt, similarity, evaluateConsultation };
+  module.exports = {
+    buildPrompt,
+    similarity,
+    evaluateConsultation,
+    handleSend,
+    callOpenAI,
+    _setTestState: state => {
+      if (state.systemPrompt !== undefined) systemPrompt = state.systemPrompt;
+      if (state.messageHistory !== undefined) messageHistory = state.messageHistory;
+      if (state.consultationScore !== undefined) consultationScore = state.consultationScore;
+      if (state.turnCount !== undefined) turnCount = state.turnCount;
+      if (state.trueDiagnosis !== undefined) trueDiagnosis = state.trueDiagnosis;
+    }
+  };
 }


### PR DESCRIPTION
## Summary
- prepend system prompt to every message before sending to OpenAI
- allow tests to modify internal state via `_setTestState`
- export `handleSend` and `callOpenAI` for tests
- test that `handleSend` uses the system prompt when invoking `callOpenAI`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_684d097bf48c8331ba2ff28a621781c3