### PR TITLE
Fix double system prompt

### DIFF
--- a/script.js
+++ b/script.js
@@ -338,7 +338,7 @@ async function handleSend() {
   turnCount += 1;
 
   console.log('sending to OpenAI. systemPrompt:', systemPrompt);
-  const messages = [{ role: 'system', content: systemPrompt }, ...messageHistory];
+  const messages = [...messageHistory];
   if (/you are the doctor|switch roles/i.test(text)) {
     messages.push({ role: 'system', content: 'Stay in the patient role at all times.' });
   }


### PR DESCRIPTION
## Summary
- prevent duplicate system messages by only using `messageHistory` when calling OpenAI

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_684d0c472b708331aacf3409521554c4