### PR TITLE
Resolve package.json syntax error

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "type": "commonjs"
-  ,
+  "type": "commonjs",
   "devDependencies": {
     "jest": "^29.0.0",
     "jsdom": "^22.0.0"


### PR DESCRIPTION
## Summary
- fix package.json comma typo causing invalid JSON

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_684d0f2bb0b48331b9989a4e1d4518d5