### PR TITLE
Fix chat input event listener

### DIFF
--- a/script.js
+++ b/script.js
@@ -510,8 +510,11 @@ document.addEventListener('DOMContentLoaded', () => {
   if (genBtn) genBtn.addEventListener('click', generateRandomCase);
   const chatInput = document.getElementById('chat-input');
   if (chatInput) {
-    chatInput.addEventListener('keypress', e => {
-      if (e.key === 'Enter') handleSend();
+    chatInput.addEventListener('keydown', e => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        handleSend();
+      }
     });
   }
 


### PR DESCRIPTION
## Summary
- use a keydown listener instead of keypress on the chat input
- prevent default action and send message when Enter is pressed

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_684d4029eddc8331922de0c7f5f9cd77