### PR TITLE
Improve startup instructions for patient simulation

### DIFF
--- a/script.js
+++ b/script.js
@@ -424,6 +424,7 @@ async function startSimulation() {
   console.log('built systemPrompt:', systemPrompt);
   messageHistory = [];
   messageHistory.push({ role: 'system', content: systemPrompt });
+  messageHistory.push({ role: 'system', content: 'Start by stating the patient\'s main concern in one sentence and do not ask the doctor any questions yet.' });
   score = 0;
   consultationScore = 50;
   turnCount = 0;
@@ -435,7 +436,7 @@ async function startSimulation() {
   document.getElementById('chat-section').style.display = 'block';
   document.getElementById('info-panels').style.display = 'grid';
   appendMessage('system', 'Simulation started.');
-  const intro = 'Begin the consultation.';
+  const intro = 'Begin the consultation by briefly stating your main concern. Do not ask the doctor any questions yet.';
   messageHistory.push({ role: 'user', content: intro });
   const firstReply = await callOpenAI(messageHistory);
   if (firstReply) {


### PR DESCRIPTION
## Summary
- refine `startSimulation()` initialization prompts
- instruct the patient to open with a concise main concern and not question the doctor

## Testing
- `npm test` *(fails: jest not installed)*

------
https://chatgpt.com/codex/tasks/task_b_684d4038a0e48331ae6c80ea92d0b31a