### PR TITLE
Combine intro prompts for VSP

### DIFF
--- a/script.js
+++ b/script.js
@@ -463,10 +463,10 @@ async function startSimulation() {
   }
 
   systemPrompt = buildPrompt();
+  systemPrompt += ' Start by stating the patient\'s main concern in one sentence and do not ask the doctor any questions yet.';
   console.log('built systemPrompt:', systemPrompt);
   messageHistory = [];
   messageHistory.push({ role: 'system', content: systemPrompt });
-  messageHistory.push({ role: 'system', content: 'Start by stating the patient\'s main concern in one sentence and do not ask the doctor any questions yet.' });
   score = 0;
   consultationScore = 50;
   turnCount = 0;


### PR DESCRIPTION
## Summary
- append the opening instruction to `systemPrompt`
- ensure only one system message is added to the history

## Testing
- `npm test --silent` *(fails: jest not installed)*

------
https://chatgpt.com/codex/tasks/task_b_684d4369ce648331bcc39e6bf68288aa