### PR TITLE
Lower temperature for deterministic outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,10 @@ Scenarios are provided as JSON files. Download [caseTemplate.json](./caseTemplat
 - `behavior` – how the patient should act during the encounter.
 
 Any field not marked as required is optional and defaults to an empty string if omitted.
+
+## Deterministic Output
+
+Both the patient responses and the random case generator use a very low
+`temperature` value (0.1) when calling the OpenAI API. This minimizes
+randomness so running the same scenario multiple times yields consistent
+dialogue and makes troubleshooting easier.

--- a/script.js
+++ b/script.js
@@ -276,7 +276,8 @@ async function callOpenAI(messages) {
       body: JSON.stringify({
         model: 'gpt-3.5-turbo',
         messages,
-        temperature: 0.7
+        // Use a near-zero temperature so patient replies are deterministic
+        temperature: 0.1
       })
     });
 
@@ -514,7 +515,8 @@ async function generateRandomCase() {
       body: JSON.stringify({
         model: 'gpt-3.5-turbo',
         messages: [{ role: 'user', content: prompt }],
-        temperature: 0.7
+        // Keep case generation consistent across runs
+        temperature: 0.1
       })
     });
 


### PR DESCRIPTION
## Summary
- update `callOpenAI` and case generation to use temperature 0.1
- document deterministic output behaviour in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_684d439c85b083318ce4955c72b98d27