### PR TITLE
Add pretest setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,13 @@ Scenarios are provided as JSON files. Download [caseTemplate.json](./caseTemplat
 - `behavior` – how the patient should act during the encounter.
 
 Any field not marked as required is optional and defaults to an empty string if omitted.
+
+## Testing
+
+Jest is used for unit tests. Run `npm install` to install dependencies before executing the tests:
+
+```bash
+npm install
+```
+
+The `pretest` script checks whether Jest is available and reminds you to install it if necessary.

--- a/checkJest.js
+++ b/checkJest.js
@@ -1,0 +1,9 @@
+const fs = require('fs');
+const path = require('path');
+
+const jestPath = path.join(__dirname, 'node_modules', '.bin', process.platform === 'win32' ? 'jest.cmd' : 'jest');
+
+if (!fs.existsSync(jestPath)) {
+  console.error('Jest is not installed. Run "npm install" before running tests.');
+  process.exit(1);
+}

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "This project provides a simple web interface for building virtual standardized patient (VSP) scenarios. Fill out the form in `index.html` to define patient details and then chat with the simulated patient powered by OpenAI's API via `script.js`.",
   "main": "script.js",
   "scripts": {
+    "pretest": "node checkJest.js",
     "test": "jest"
   },
   "keywords": [],


### PR DESCRIPTION
## Summary
- document running tests in README
- add pretest script to check for Jest and prompt for `npm install`

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: Jest is not installed)*

------
https://chatgpt.com/codex/tasks/task_b_684d43a384908331b9e242d1cb57cce9