### PR TITLE
Handle null responses from OpenAI

### DIFF
--- a/script.js
+++ b/script.js
@@ -418,6 +418,8 @@ async function handleSend() {
     appendMessage('assistant', reply);
     messageHistory.push({ role: 'assistant', content: reply });
     saveCurrentSession();
+  } else {
+    appendMessage('system', '(No response from OpenAI)');
   }
 
   if (turnCount % 5 === 0) {
@@ -484,6 +486,8 @@ async function startSimulation() {
   if (firstReply) {
     appendMessage('assistant', firstReply);
     messageHistory.push({ role: 'assistant', content: firstReply });
+  } else {
+    appendMessage('system', '(No response from OpenAI)');
   }
   saveCurrentSession();
 }


### PR DESCRIPTION
## Summary
- add fallback messages when the OpenAI API returns `null`

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_684d43b132448331a84b8f06b22ff6fe