### PR TITLE
Fix input disabled state on new sessions

### DIFF
--- a/script.js
+++ b/script.js
@@ -157,6 +157,10 @@ function loadSession(id) {
   score = session.score || 0;
   consultationScore = session.consultationScore || 50;
   turnCount = session.turnCount || 0;
+  const input = document.getElementById('chat-input');
+  const send = document.getElementById('send-btn');
+  if (input) input.disabled = false;
+  if (send) send.disabled = false;
   if (messageHistory.length > 0) {
     document.getElementById('chat-section').style.display = 'block';
     document.getElementById('info-panels').style.display = 'grid';
@@ -451,6 +455,11 @@ async function startSimulation() {
   if (!currentSessionId) {
     createNewSession(caseData || {});
   }
+
+  const input = document.getElementById('chat-input');
+  const send = document.getElementById('send-btn');
+  if (input) input.disabled = false;
+  if (send) send.disabled = false;
 
   if (messageHistory.length > 0) {
     const cb = document.getElementById('case-builder');


### PR DESCRIPTION
## Summary
- reset chat input and send button when starting a simulation
- enable input controls when loading a saved session

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_684d43b3f21c83318af86baa4144be12